### PR TITLE
Update nx.command-runners and nx.form-renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ require('nx.nvim').setup{
 
     -- Command running capabilities,
     -- see nx.m.command-runners for more details
-    command_runner = require('nx.command-runners').terminal_command_runner(),
+    command_runner = require('nx.command-runners').terminal_cmd(),
     -- Form rendering capabilities,
     -- see nx.m.form-renderers for more detials
-    form_renderer = require('nx.form-renderers').telescope_form_renderer(),
+    form_renderer = require('nx.form-renderers').telescope(),
 
     -- Whether or not to load nx configuration,
     -- see nx.loading-and-reloading for more details


### PR DESCRIPTION
The methods for `command_runner` and `form_renderer` seem to have changed, I had to update the config to:

```lua
    command_runner = require('nx.command-runners').terminal_cmd(),
    form_renderer = require('nx.form-renderers').telescope(),
```