### PR TITLE
fix(read-configs): json decode + nil schema

### DIFF
--- a/lua/nx/read-configs.lua
+++ b/lua/nx/read-configs.lua
@@ -57,8 +57,13 @@ function _M.rf(fname, callback)
 				end
 
 				vim.loop.fs_close(fd, function()
-					local table = vim.json.decode(data)
-					callback(table, true)
+					local success, table = pcall(vim.json.decode, data)
+					if success then
+						callback(table, true)
+					else
+						console.error('Failed to decode JSON: ' .. fname)
+						callback(table, false)
+					end
 				end)
 			end)
 		end)
@@ -143,7 +148,6 @@ function _M.read_workspace_generators(callback)
 		end
 	end)
 
-
 	local function add_gen(gensTable, value, name, schema)
 		if schema then
 			table.insert(gensTable, {
@@ -161,32 +165,31 @@ function _M.read_workspace_generators(callback)
 		_M.rf(path .. '/package.json', function(f)
 			local function handle_schematic_file(field)
 				if f[field] then
-					_M.rf(
-						path .. '/' .. f[field],
-						function(schematics)
-							local possibleGeneratorNames = { 'generators', 'schematics' }
-							for _, generators in pairs(possibleGeneratorNames) do
-								if schematics and schematics[generators] then
-									local genCount = 0
-									local loadedGenCount = 0
+					_M.rf(path .. '/' .. f[field], function(schematics)
+						local possibleGeneratorNames =
+							{ 'generators', 'schematics' }
+						for _, generators in pairs(possibleGeneratorNames) do
+							if schematics and schematics[generators] then
+								local genCount = 0
+								local loadedGenCount = 0
 
-									for name, gen in pairs(schematics[generators]) do
-										genCount = genCount + 1
+								for name, gen in pairs(schematics[generators]) do
+									genCount = genCount + 1
 
-										_M.rf(path .. '/' .. gen.schema,
-											function(schema)
-												add_gen(gens, f.name, name, schema)
+									_M.rf(
+										path .. '/' .. gen.schema,
+										function(schema)
+											add_gen(gens, f.name, name, schema)
 
-												loadedGenCount = loadedGenCount + 1
-											end
-										)
-									end
-
-									-- If no generators found for this package, update loadedCount directly
+											loadedGenCount = loadedGenCount + 1
+										end
+									)
 								end
+
+								-- If no generators found for this package, update loadedCount directly
 							end
 						end
-					)
+					end)
 				end
 			end
 
@@ -278,42 +281,50 @@ function _M.read_external_generators(callback)
 		_M.rf('./node_modules/' .. value .. '/package.json', function(f)
 			local function handle_schematic_file(field)
 				if f[field] then
-					local schematics_path = './node_modules/' .. value .. '/' .. f[field]
-					local schematics_dir = vim.fn.fnamemodify(schematics_path, ':p:h')
-					_M.rf(
-						schematics_path,
-						function(schematics)
-							local possibleGeneratorNames = { 'generators', 'schematics' }
-							for _, generators in pairs(possibleGeneratorNames) do
-								if schematics and schematics[generators] then
-									local genCount = 0
-									local loadedGenCount = 0
+					local schematics_path = './node_modules/'
+						.. value
+						.. '/'
+						.. f[field]
+					local schematics_dir =
+						vim.fn.fnamemodify(schematics_path, ':p:h')
+					_M.rf(schematics_path, function(schematics)
+						local possibleGeneratorNames =
+							{ 'generators', 'schematics' }
+						for _, generators in pairs(possibleGeneratorNames) do
+							if schematics and schematics[generators] then
+								local genCount = 0
+								local loadedGenCount = 0
 
-									for name, gen in pairs(schematics[generators]) do
-										genCount = genCount + 1
+								for name, gen in pairs(schematics[generators]) do
+									genCount = genCount + 1
 
-										_M.rf(schematics_dir .. '/' .. gen.schema,
+									if gen.schema then
+										_M.rf(
+											schematics_dir .. '/' .. gen.schema,
 											function(schema)
 												add_gen(value, name, schema)
 
-												loadedGenCount = loadedGenCount + 1
-												if loadedGenCount == genCount then
+												loadedGenCount = loadedGenCount
+													+ 1
+												if
+													loadedGenCount == genCount
+												then
 													maybe_continue()
 												end
 											end
 										)
 									end
+								end
 
-									-- If no generators found for this package, update loadedCount directly
-									if genCount == 0 then
-										maybe_continue()
-									end
-								else
+								-- If no generators found for this package, update loadedCount directly
+								if genCount == 0 then
 									maybe_continue()
 								end
+							else
+								maybe_continue()
 							end
 						end
-					)
+					end)
 				else
 					maybe_continue()
 				end


### PR DESCRIPTION
In 2 different projects where I use nx.nvim I met the below errors:

With the first one, I was getting the following error every time I opened nvim: 
-> attempt to concatenate field 'schema' (a nil value) in 'callback'. 
This commit adds a check on the schema value and resolves the issue.

At the 2nd one, I was getting the following errors popping up everytime I was opening nvim:
-> expected object key string but found T_OBJ_END at character ... in 'decode'.
-> expected object value but found T_ARR_END at character ... in 'decode'.
After ignoring them, my generators and actions list was empty. 
This commit adds a protected call, and the actions and generators lists are now populated, with no errors popping up.